### PR TITLE
include preprocessor files for use in dependent projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "files": [
     "dist/ofi.browser.js",
     "dist/ofi.common-js.js",
-    "dist/ofi.es-modules.js"
+    "dist/ofi.es-modules.js",
+    "preprocessors"
   ],
   "main": "dist/ofi.common-js.js",
   "jsnext:main": "dist/ofi.es-modules.js",


### PR DESCRIPTION
Hello!

I noticed that after I installed this polyfill as a dependency in my project, the preprocessor files were not included in node_modules.

I thought maybe they should. If you think so too, doing something like this would make that happen.

Cheers,
Matt
