### PR TITLE
Fix handling of img nodelist/array

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ export default function fix(imgs, opts) {
 	// use imgs as a selector or just select all images
 	if (typeof imgs === 'string') {
 		imgs = document.querySelectorAll('img');
-	} else if ('length' in imgs) {
+	} else if (!'length' in imgs) {
 		imgs = [imgs];
 	}
 


### PR DESCRIPTION
When `fix` is called with an array of nodes or a nodelist, the function incorrectly wraps it inside another array (eg: [el, el] becomes [[el, el]]) which causes type errors