### PR TITLE
Fix: Allow object-fit to go from "cover" to 'fill' mode.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,17 @@ function fixOne(el, requestedSrc) {
 		) {
 			return;
 		}
+	} 
+	if (el[ಠ].s && "fill" === style["object-fit"]) {
+		el.style.backgroundImage = '';
+    	el.style.backgroundRepeat = '';
+    	el.style.backgroundPosition = '';
+    	el.style.backgroundSize = '';
+        nativeSetAttribute.call(el, 'src', el[ಠ].s);
+    	if (el[ಠ].srcsetAttr) {
+            nativeSetAttribute.call(el, 'srcset', el[ಠ].srcsetAttr);
+    	}
+    	return;
 	}
 
 	let src = el[ಠ].ios7src || el.currentSrc || el.src;
@@ -108,6 +119,8 @@ function fixOne(el, requestedSrc) {
 		}
 	}
 
+	nativeSetAttribute.call(el, 'src', ಠ);
+    nativeSetAttribute.call(el, 'srcset', '');
 	el.style.backgroundImage = 'url("' + src + '")';
 	el.style.backgroundPosition = style['object-position'] || 'center';
 	el.style.backgroundRepeat = 'no-repeat';

--- a/index.js
+++ b/index.js
@@ -46,15 +46,11 @@ function fixOne(el, requestedSrc) {
 		}
 	} 
 	if (el[ಠ].s && "fill" === style["object-fit"]) {
-		el.style.backgroundImage = '';
-    	el.style.backgroundRepeat = '';
-    	el.style.backgroundPosition = '';
-    	el.style.backgroundSize = '';
-        nativeSetAttribute.call(el, 'src', el[ಠ].s);
-    	if (el[ಠ].srcsetAttr) {
-            nativeSetAttribute.call(el, 'srcset', el[ಠ].srcsetAttr);
-    	}
-    	return;
+		nativeSetAttribute.call(el, 'src', el[ಠ].s);
+		if (el[ಠ].srcsetAttr) {
+			nativeSetAttribute.call(el, 'srcset', el[ಠ].srcsetAttr);
+		}
+		return;
 	}
 
 	let src = el[ಠ].ios7src || el.currentSrc || el.src;
@@ -120,7 +116,7 @@ function fixOne(el, requestedSrc) {
 	}
 
 	nativeSetAttribute.call(el, 'src', ಠ);
-    nativeSetAttribute.call(el, 'srcset', '');
+	nativeSetAttribute.call(el, 'srcset', '');
 	el.style.backgroundImage = 'url("' + src + '")';
 	el.style.backgroundPosition = style['object-position'] || 'center';
 	el.style.backgroundRepeat = 'no-repeat';


### PR DESCRIPTION
I was hitting a problem where I needed the image to go back to using its 'src' as it needed to calculate its height for mobile (otherwise it kept its first calculated height and looked broken if you switched from desktop-mobile)

**Use case:** A card item starts in desktop as a 2-column text-image view (with object-fit:cover) and changes to a image-text stack view. (object-fit: fill / default)

Tested: IE11, Edge