### PR TITLE
Bugfix: use OFI image on attribute get/set if defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ function keepSrcUsable(el) {
 
 function hijackAttributes() {
 	function getOfiImageMaybe(el, name) {
-		return el[OFI] && (name === 'src' || name === 'srcset') ? el[OFI].img : el;
+		return el[OFI] && el[OFI].img && (name === 'src' || name === 'srcset') ? el[OFI].img : el;
 	}
 	if (!supportsObjectPosition) {
 		HTMLImageElement.prototype.getAttribute = function (name) {


### PR DESCRIPTION
When objectFitImages is called, a new [OFI] ('bfred-it:object-fit-images') property is created for each target element. The cloned img inside this property is defined only if needed.
Inside the hijackAttributes function there is no check whether or not the img property exists. 
This leads to error "script65535 invalid calling object" when setAttribute is used on images without object-fit