### PR TITLE
Allow node to require/import ofi without throwing an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const OFI = 'bfred-it:object-fit-images';
 const propRegex = /(object-fit|object-position)\s*:\s*([-\w\s%]+)/g;
-const testImg = new Image();
+const testImg = typeof Image === 'undefined' ? {style: {'object-position': 1}} : new Image();
 const supportsObjectFit = 'object-fit' in testImg.style;
 const supportsObjectPosition = 'object-position' in testImg.style;
 const supportsOFI = 'background-size' in testImg.style;


### PR DESCRIPTION
When OFI is required/imported in node, it throws some errors.

SomeComponent.js
`import fit from "object-fit-images"` 

```
var testImg = new Image();
                  ^
ReferenceError: Image is not defined
```

We are using OFI in a react component which is run on the client and on the server. 

We don't call `fit` on the server. Our current work around is to dynamically require on the client only.

I tested this doesn't throw by running `node dist/ofi.common-js.js`