### PR TITLE
Image tag fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,14 +177,15 @@ function hijackAttributes() {
 export default function fix(imgs, opts) {
 	const startAutoMode = !autoModeEnabled && !imgs;
 	opts = opts || {};
-	imgs = imgs || 'img';
 
 	if ((supportsObjectPosition && !opts.skipTest) || !supportsOFI) {
 		return false;
 	}
 
 	// use imgs as a selector or just select all images
-	if (typeof imgs === 'string') {
+	if (!imgs) {
+		imgs = document.getElementsByTagName('img');
+	} else if (typeof imgs === 'string') {
 		imgs = document.querySelectorAll(imgs);
 	} else if (!('length' in imgs)) {
 		imgs = [imgs];

--- a/index.js
+++ b/index.js
@@ -177,13 +177,14 @@ function hijackAttributes() {
 export default function fix(imgs, opts) {
 	const startAutoMode = !autoModeEnabled && !imgs;
 	opts = opts || {};
+	imgs = imgs || 'img';
 
 	if ((supportsObjectPosition && !opts.skipTest) || !supportsOFI) {
 		return false;
 	}
 
 	// use imgs as a selector or just select all images
-	if (!imgs) {
+	if (imgs === 'img') {
 		imgs = document.getElementsByTagName('img');
 	} else if (typeof imgs === 'string') {
 		imgs = document.querySelectorAll(imgs);


### PR DESCRIPTION
After turning on the mq: watch, another bug was found.
```
imgs = 'img'; // reset to a generic selector for watchMQ
```
This line broke a new check. 