### PR TITLE
add es6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "preprocessors"
   ],
   "main": "dist/ofi.common-js.js",
+  "module": "dist/ofi.es-modules.js",
   "scripts": {
     "build:js": "bfred-npm-bundler ofi objectFitImages",
     "build": "npm-run-all --silent jsfix build:*",


### PR DESCRIPTION
specifying the `module` field in `package.json` enables front end tools to identify the es modules entry point for the project. This is a simple change and enables me to use object-fit-images in my project.